### PR TITLE
Fix goroutine leak caused by connection error during IDLE

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	defaultLogoutTimeout = 25 * time.Minute
-	defaultPollInterval = time.Minute
+	defaultPollInterval  = time.Minute
 )
 
 // Client is an IDLE client.
@@ -31,7 +31,7 @@ func (c *Client) idle(stop <-chan struct{}) error {
 	cmd := &Command{}
 
 	res := &Response{
-		Stop:   stop,
+		Stop:      stop,
 		RepliesCh: make(chan []byte, 10),
 	}
 
@@ -70,6 +70,7 @@ func (c *Client) Idle(stop <-chan struct{}) error {
 			close(stopOrRestart)
 			return <-done
 		case err := <-done:
+			close(stopOrRestart)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Hi, thanks for creating go-imap. I’m really enjoying working with it and learning Golang in the process.

Using pprof I found a dangling goroutine when idle is ended due to lost connection. Closing `stopOrRestart` in that case fixes the issue.