### PR TITLE
Introduce Mailbox.Idle to accomodate for go-imap v2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ for {
 s.Enable(idle.NewExtension())
 ```
 
+Backend should implement Backend interface defined in this package.
+
 ## License
 
 MIT

--- a/server.go
+++ b/server.go
@@ -13,11 +13,32 @@ type Handler struct {
 	Command
 }
 
+type Mailbox interface {
+	/*
+	Idle allows backend to send updates without explicit Poll calls or any other
+	commands running.
+
+	When called - it should block indefinitely and return immediately when
+	done channel is written to.
+	*/
+	Idle(done <-chan struct{})
+}
+
 func (h *Handler) Handle(conn server.Conn) error {
 	cont := &imap.ContinuationReq{Info: "idling"}
 	if err := conn.WriteResp(cont); err != nil {
 		return err
 	}
+
+	if mbox, ok := conn.Context().Mailbox.(Mailbox); ok {
+		done := make(chan struct{})
+		go mbox.Idle(done)
+		defer func() {
+			done <- struct{}{}
+		}()
+	}
+	// TODO(foxcpp): Fallback to short-interval polling if backend does not support
+	// corresponding interface?
 
 	// Wait for DONE
 	scanner := bufio.NewScanner(conn)


### PR DESCRIPTION
See #15.

Not to be merged now, I suppose.
