### PR TITLE
Always announce IDLE capability

### DIFF
--- a/server.go
+++ b/server.go
@@ -35,10 +35,7 @@ func (h *Handler) Handle(conn server.Conn) error {
 type extension struct{}
 
 func (ext *extension) Capabilities(c server.Conn) []string {
-	if c.Context().State&imap.AuthenticatedState != 0 {
-		return []string{Capability}
-	}
-	return nil
+	return []string{Capability}
 }
 
 func (ext *extension) Command(name string) server.HandlerFactory {


### PR DESCRIPTION
Some clients, such as microsoft outlook, are confused by the fact that the server doesn't always announce the IDLE capability and as a result refuse to use the IDLE command. I think we should always announce the IDLE capability, regardless of the connection state. This change makes microsoft outlook comfortable to use the IDLE command again. And in my opinion, it's logically correct: the server does indeed support IDLE, the conn state itself isn't so important (e.g. we also announce the full IMAP4rev1 capability despite only a subset of the implied commands being supported in some states).